### PR TITLE
Contributor and User Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# MESH Creative Coding Studio
+
+MESH is a browser-native p5.js playground designed for collaborative, remix-driven creative coding. The workspace pairs a Monaco code editor with a live canvas, built-in console logging, and publishing tools that post sketches straight to Bluesky. An archive view aggregates every `#meshArchive` post so the community can keep riffing on each other's discoveries.
+
+- **Zero-setup studio**: open the editor, tweak the sketch, and see the canvas update instantly thanks to a custom p5 runner.
+- **Creative remix kit**: start from the included glitch preset or load your own assets, iterate with auto-run, and capture happy accidents.
+- **Publishing pipeline**: push the output canvas to Bluesky without leaving the app; add CC-BY-SA licensing in one switch.
+- **Community archive**: explore the live feed of `#meshArchive` experiments pulled from Bluesky and documented for future zines.
+- **Thoughtful UX**: responsive layout, theme toggle, keyboard-friendly controls, and console mirroring for easy debugging.
+
+## Getting started (development)
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Visit `http://localhost:3000` to open the workspace.
+
+### Prerequisites
+
+- Node.js 22.x (enforced via the repository's Volta pin)
+- pnpm 9+
+
+### Environment variables
+
+Create a `.env.local` file to enable the archive feed to authenticate against Bluesky's APIs:
+
+```ini
+BLUESKY_IDENTIFIER=you.bsky.social
+BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+```
+
+Without these values the archive will gracefully degrade, but authenticated credentials improve reliability. Use a Bluesky *app password*, not your main login.
+
+## Development workflow
+
+- `pnpm dev`: install dependencies (idempotent) and launch the Next.js development server
+- `pnpm build`: create an optimized production build
+- `pnpm start`: build and run the production server
+- `pnpm lint`: run ESLint with the Next.js config
+
+Recommended flow:
+
+1. `pnpm install`
+2. Create a feature branch
+3. Build or run locally (`pnpm dev`)
+4. Run `pnpm lint` (and any manual smoke tests) before opening a pull request
+
+We run a zero-trust policy for credentials. Never commit `.env*` files or hard-coded secrets.
+
+## Architecture overview
+
+| Path | Purpose |
+| ---- | ------- |
+| `app/` | Next.js routes, including the editor workspace (`page.tsx`) and archive API. |
+| `components/` | UI building blocks: Monaco editor wrapper, canvas, console, Bluesky form, and shared workspace shells. |
+| `hooks/` | Client hooks: `useEditor` exposes Redux-backed editor state; `useP5` wraps the custom runner. |
+| `lib/` | Platform utilities: theme helpers, Bluesky client, console bridge, and the `P5Runner`. |
+| `store/` | Redux store configuration and slice powering the editor. |
+| `docs/` | End-user documentation published via GitHub Pages. |
+
+Key files to know:
+
+- `store/editorSlice.ts`: default sketch source and editor state machine
+- `lib/p5runner.ts`: wraps p5 instance mode, handling logs and error reporting
+- `components/Canvas.tsx`: binds the runner to the live preview
+- `app/api/archive/route.ts`: serverless route that fetches `#meshArchive` posts
+
+## Quality gates
+
+- `pnpm lint`: ensure ESLint passes before pushing
+- Manual smoke test: verify the editor runs and the preview responds to changes
+- Optional: capture canvas screenshots or screen recordings for UI-focused PRs
+
+## Documentation for users
+
+End-user documentation lives in `docs/`, which can be published with GitHub Pages (`Settings -> Pages -> Source: Deploy from docs/`). The entry point is [`docs/index.md`](docs/index.md), which links to:
+
+- [`docs/ide-guide.md`](docs/ide-guide.md): interface tour, shortcuts, troubleshooting
+- [`docs/creative-remix-playbook.md`](docs/creative-remix-playbook.md): remix methodology
+- [`docs/tutorials/01-remix-the-glitch-preset.md`](docs/tutorials/01-remix-the-glitch-preset.md): guided preset remix
+- [`docs/tutorials/02-live-interaction.md`](docs/tutorials/02-live-interaction.md): animate and perform a sketch
+- [`docs/tutorials/03-dynamic-controls.md`](docs/tutorials/03-dynamic-controls.md): build keyboard and pointer controls
+- [`docs/tutorials/04-archive-ready-export.md`](docs/tutorials/04-archive-ready-export.md): manage Picsum feeds and custom image assets
+
+When GitHub Pages is enabled, share the published URL (for example `https://<org>.github.io/mesh/`) with participants and link it from community announcements.
+
+## Contributing
+
+- Fork or branch from `main`
+- Follow the development workflow above
+- Submit a pull request with context, screenshots when visual changes apply, and links to any relevant GitHub Pages updates
+- Ensure automated checks pass before requesting review
+
+## License
+
+The application code is released under an open source license (add here when selected). Sketches published from the editor can optionally append `#meshArchive CC-BY-SA` so the community can remix with attribution.

--- a/docs/creative-remix-playbook.md
+++ b/docs/creative-remix-playbook.md
@@ -1,0 +1,107 @@
+# Creative Remix Playbook
+
+This playbook outlines a repeatable process for remixing the bundled glitch sketch and crafting new pieces inside MESH. Adapt the steps to suit your own prompts, collaborators, or exhibition deadlines.
+
+## 1. Read the preset
+
+Start by skimming the preset definitions in `store/editorSlice.ts:16`:
+
+- `preset.effectChain` is an ordered list of filters executed in `draw()`.
+- `effectFunctions` contains the implementation for each named effect.
+- The sketch pulls an image from `https://picsum.photos/600` during `preload()`.
+
+Write a short summary of how energy flows through the chain. For example: pixelate -> split RGB -> tear slices -> add noise -> quantize -> dither -> scanlines -> ghost buffer -> invert -> posterize. The order matters; swapping items can yield radically different results.
+
+## 2. Set an iteration goal
+
+Pick a constraint before editing:
+
+- **Color study**: keep structure intact but add tints, gradients, or palette swaps.
+- **Motion study**: re-enable a continuous loop (remove `noLoop()`) and experiment with temporal effects like `frameCount` driven shifts.
+- **Structural remix**: remove half the chain, reorder effects, or insert new ones inspired by analog texture workflows.
+
+Document the question you want the remix to answer. Having a statement keeps the experiment from becoming noise.
+
+## 3. Isolate parameters
+
+Create a scratchpad near the top of the sketch:
+
+```js
+const controls = {
+  pixelate: 34,
+  rgbOffset: { maxOffset: 12, alpha: 110 },
+  quantizeLevels: 10,
+};
+```
+
+Reference this object inside the relevant effect calls. Now you can run quick parameter sweeps by editing one number at a time. Combine this with auto-run disabled so you can edit multiple knobs before triggering a render.
+
+## 4. Fork an effect
+
+Copy one of the functions in `effectFunctions` and rename it. For example, duplicate `scanlines` into `scanlinesWide` and adjust its loop:
+
+```js
+effectFunctions.scanlinesWide = ({ spacing, alpha }) => {
+  fill(0, alpha);
+  for (let y = 0; y < height; y += spacing * 2) {
+    rect(0, y, width, spacing);
+  }
+};
+```
+
+Add the new entry to `preset.effectChain`. The runner will pick it up on the next execution because of the wrapper inside `lib/p5runner.ts` that rebinds lifecycle hooks each run.
+
+## 5. Swap the source material
+
+Drop a file into `public/`. Example: `public/assets/mesh-portrait.jpg`. Replace the loader call:
+
+```js
+img = loadImage('/assets/mesh-portrait.jpg');
+```
+
+If you want to audition several sources, build a small list and use keyboard input:
+
+```js
+const sources = ['/assets/a.jpg', '/assets/b.jpg'];
+let sourceIndex = 0;
+
+function keyPressed() {
+  if (key === ' ') {
+    sourceIndex = (sourceIndex + 1) % sources.length;
+    loadImage(sources[sourceIndex], (next) => {
+      img = next;
+      redraw();
+    });
+  }
+}
+```
+
+Remember to call `redraw()` if you've disabled auto-run.
+
+## 6. Capture variations
+
+- Use `console.log` to note parameter combos as you discover sweet spots.
+- Click the share icon and publish to Bluesky with a caption that records the variation (e.g., `pixelate=24, quantize=4`).
+- Tag iterated frames with `#meshArchive` so they land in the Archive page for later reference.
+
+## 7. Reflect and package
+
+After a session, answer these prompts to synthesize the work:
+
+1. What did the original chain do well? Where did it resist modification?
+2. Which new effect or ordering produced the biggest surprise?
+3. How would you explain the remix to another artist in two sentences?
+4. What reusable snippets should live in an external gist or template sketch?
+
+Add the strongest variations to your personal library or zine submission. Keep your notes in the repository alongside the sketch so the next collaborator can trace your intent.
+
+## 8. Reset for the next collaborator
+
+When you are ready to hand off:
+
+- Export or capture the final canvas.
+- Clear noisy logs via the console panel.
+- Decide whether to leave the remix in-place (so the next artist builds on it) or paste the original preset back into the editor.
+- Write a short README entry or commit message summarizing the session.
+
+Building this rhythm ensures MESH remains a living studio instead of a static demo.

--- a/docs/ide-guide.md
+++ b/docs/ide-guide.md
@@ -1,0 +1,76 @@
+# MESH IDE Guide
+
+This guide walks through the workspace layout, controls, and best practices for working inside the MESH creative coding studio.
+
+## Workspace layout
+
+- **Header bar**: Switch between the Editor, Archive, and About pages using the menu in the top right. The header also exposes the theme toggle.
+- **Editor column**: Shows the Monaco editor bound to `sketch.js`. The Redux store (`store/editorSlice.ts`) keeps the code in sync so you never lose changes during navigation.
+- **Preview column**: Runs the active sketch in an embedded p5 canvas. The dock attached to the bottom of this column hosts the console and publishing tools.
+- **Footer bar**: Contains five actions (run, stop, auto-run toggle, console panel, publishing panel). Hover any icon to see its tooltip.
+
+The layout requires a desktop-class viewport (`min-width: 1024px`). On smaller screens the About page renders instead of the editor.
+
+## Editing code
+
+- Monaco provides syntax highlighting, bracket matching, linting, and JavaScript intellisense.
+- The editor path is fixed to `sketch.js`; helper files must live inside the sketch string itself or be loaded at runtime (for example via `loadImage`).
+- Use standard Monaco shortcuts: `Cmd`/`Ctrl`+`F` to find in file, `Alt`+`Arrow` to move lines, and `Cmd`/`Ctrl`+`Enter` to run the current statement in the console (when focused).
+- The default sketch lives in `store/editorSlice.ts:16` and loads a glitch processing pipeline. Refreshing the page resets the editor to this preset.
+
+## Running sketches
+
+- **Auto-run**: Enabled by default. Any edit to the code triggers a recompile and re-run. Toggle the lightning icon in the footer to disable auto execution when debugging.
+- **Manual run**: Click the play icon or press `Cmd`/`Ctrl`+`Shift`+`Enter` (Monaco's run shortcut) to execute the latest version.
+- **Stop**: Use the square icon to call `noLoop()` on the current p5 instance. This is helpful when a sketch animates indefinitely.
+
+The custom runner (`lib/p5runner.ts`) wraps your sketch in instance mode, mirrors console output, and preserves global-mode idioms such as `setup` or `draw`.
+
+## Console and logging
+
+- Open the console panel via the terminal icon. Logs stream from `console.log`, `console.warn`, `console.error`, and `window.onerror` through the bridge defined in `lib/consoleBridge.ts`.
+- Messages are prefixed with `[log]`, `[warn]`, or `[error]` for quick scanning.
+- Click **Clear** to reset the buffer. The panel remains attached to the preview column to keep logs near the canvas.
+
+## Publishing to Bluesky
+
+1. Run your sketch and confirm the canvas shows the frame you want to publish.
+2. Open the publishing panel from the share icon. This mounts `components/BlueskyPost.tsx`.
+3. Enter your Bluesky handle and an *app password* (create one at `https://bsky.app/settings/app-passwords`).
+4. Write a caption. Enable the CC-BY-SA switch if you want the helper text `#meshArchive CC-BY-SA` appended automatically.
+5. Click **Publish**. The client captures the current canvas, uploads it, and posts through Bluesky's upload API.
+6. Watch the inline status indicator for success or error messages.
+
+Credentials are never persisted. Refresh the page to clear the form entirely.
+
+## Archive view
+
+Select **Archive** in the header to load the feed at `/api/archive`. The route aggregates recent posts tagged `#meshArchive` via Bluesky search endpoints. Infinite scroll attempts to prefetch in batches of 30. Use **Retry** if a provider throttles the request.
+
+To enable authenticated lookup (which improves reliability), set `BLUESKY_IDENTIFIER` and `BLUESKY_APP_PASSWORD` in `.env.local` before running the dev server.
+
+## Working with assets
+
+- Remote assets: use `loadImage`, `loadJSON`, or other p5 loaders with full URLs. For example, `loadImage('https://picsum.photos/600')` in the default sketch.
+- Local assets: place files in `public/` and reference them by path (`/assets/texture.png`). Remember that hot reloading might not trigger if the file cache persists; reload the page if necessary.
+- Generated buffers such as `createGraphics` are preserved between frames. Store them in module-scope variables to maintain state, as shown with `ghostBuf` in the preset.
+
+## Troubleshooting
+
+- **Blank canvas**: Check the console panel for runtime errors. Syntax errors log as `[error] Unexpected identifier` with the relevant line.
+- **Stuck sketch**: Click the stop icon to cancel the draw loop, or toggle auto-run off before editing heavier sketches.
+- **No canvas detected for publishing**: Ensure the sketch executed at least once. If the publish form still reports `No canvas`, click **Run** to regenerate the frame.
+- **Archive errors**: Missing environment variables or upstream rate limiting will show in the alert banner. Retry or open the Bluesky search link directly.
+
+## Keyboard cheat sheet
+
+| Action | Shortcut |
+| ------ | -------- |
+| Run sketch | `Cmd`/`Ctrl`+`Shift`+`Enter`
+| Toggle sidebar panels | Click the terminal or share icons in the footer (tooltips show labels)
+| Quick command palette | `F1` or `Cmd`/`Ctrl`+`Shift`+`P`
+| Duplicate line | `Shift`+`Alt`+`Arrow Down`
+| Move line | `Alt`+`Arrow Up/Down`
+| Multi-cursor | `Cmd`/`Ctrl`+`Click`
+
+The Monaco command palette exposes many more bindings; press `F1` while focused in the editor to explore.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+# MESH Studio Guide
+
+Welcome to MESH, a browser-based p5.js playground built for remix-driven creative coding. This site collects the user-facing documentation you can publish via GitHub Pages.
+
+## What you can do
+
+- Edit the built-in glitch preset and see changes instantly in the live canvas
+- Remix sketches with console logging, theme-aware UI, and optional auto-run
+- Publish captured frames directly to Bluesky with CC-BY-SA licensing helpers
+- Browse the `#meshArchive` community feed without leaving the workspace
+
+## Start here
+
+1. Open the studio at `http://localhost:3000` (or your deployed URL) on a desktop-sized screen.
+2. Read the [IDE Guide](ide-guide.md) for an interface tour and troubleshooting tips.
+3. Follow the [Remix Playbook](creative-remix-playbook.md) to establish a remix workflow.
+4. Dive into hands-on tutorials:
+   - [Tutorial 01: Remix the Glitch Preset](tutorials/01-remix-the-glitch-preset.md)
+   - [Tutorial 02: Animate and Perform a Sketch](tutorials/02-live-interaction.md)
+   - [Tutorial 03: Build Live Controls](tutorials/03-dynamic-controls.md)
+   - [Tutorial 04: Source Images with Picsum and Custom Assets](tutorials/04-archive-ready-export.md)
+
+## Publishing to Bluesky
+
+See the [IDE Guide](ide-guide.md#publishing-to-bluesky) for the full walkthrough.
+
+Quick checklist:
+
+- Ensure a sketch has run and a canvas is visible.
+- Use a Bluesky app password, not your primary login.
+- Add captions that describe the remix and include `#meshArchive` for the community archive.
+
+## Keep exploring
+
+- Share your findings in community channels or the `#meshArchive` feed.
+- Contribute new tutorials by adding markdown files inside `docs/tutorials/`.
+- Report issues or ideas through GitHub discussions or issues.
+
+If you are hosting this documentation with GitHub Pages, update project settings (`Settings -> Pages -> Source: docs/`) so `docs/index.md` becomes the landing page.

--- a/docs/tutorials/01-remix-the-glitch-preset.md
+++ b/docs/tutorials/01-remix-the-glitch-preset.md
@@ -1,0 +1,86 @@
+# Tutorial 01: Remix the Glitch Preset
+
+This walkthrough guides you through modifying the built-in glitch sketch, dialing in custom parameters, and capturing a shareable frame.
+
+## 1. Load the editor
+
+1. Run `pnpm dev` and open `http://localhost:3000` in a desktop browser.
+2. Confirm auto-run is enabled (the lightning icon in the footer is highlighted). If you prefer manual control, toggle it off now.
+
+## 2. Reduce pixelation for finer detail
+
+1. Locate the `pixelate` entry near the top of the sketch.
+2. Change the `size` parameter from `50` to `18`:
+
+   ```js
+   { name:'pixelate', params:{ size: 18 } },
+   ```
+
+3. Run the sketch. The canvas should reveal more of the source image while retaining blocky geometry.
+
+## 3. Reorder the RGB offset
+
+1. Move the `{ name:'rgbOffset', ... }` line so it appears **after** the slice effects (`hSliceShift` and `vSliceTear`).
+2. Re-run or allow auto-run to trigger. Offsetting after the tears preserves more texture and yields saturated overlays.
+
+## 4. Add a custom burn-in pass
+
+1. Scroll down to the `effectFunctions` object and append a new function definition:
+
+   ```js
+   burnIn({ alpha = 30 }) {
+     blendMode(ADD);
+     tint(255, 90, 0, alpha);
+     image(img, 0, 0);
+     noTint();
+     blendMode(BLEND);
+   },
+   ```
+
+2. Insert the effect into the chain right before `ghosting`:
+
+   ```js
+   { name:'burnIn', params:{ alpha: 45 } },
+   { name:'ghosting', params:{ alpha:60 } },
+   ```
+
+3. Run again. The canvas now blooms with warm highlights before the ghost buffer settles the frame.
+
+## 5. Explore quick variations
+
+1. Disable auto-run temporarily.
+2. Wrap the adjustable numbers in a `controls` object:
+
+   ```js
+   const controls = {
+     pixelateSize: 18,
+     burnInAlpha: 45,
+     quantizeLevels: 12,
+   };
+   ```
+
+3. Replace literals with the control values. Example:
+
+   ```js
+   { name:'pixelate', params:{ size: controls.pixelateSize } },
+   ...
+   burnIn({ alpha = controls.burnInAlpha }) {
+   ```
+
+4. Change multiple values, then click **Run** once to compare batches of variations without overloading the runner.
+5. Log your favorites via `console.log('Preset A', controls);` so the console panel records them.
+
+## 6. Capture and publish
+
+1. When a frame resonates, open the share panel.
+2. Add a caption noting the variation (e.g., `pixelate=18 burnIn=45 quantize=6`).
+3. Enable the CC-BY-SA switch if you intend to submit the work to the zine.
+4. Publish to Bluesky. Once the status reads `Posted`, use the provided link to view the entry live.
+
+## 7. Save your remix
+
+- Copy the final sketch into a new gist or commit.
+- Optionally paste the remix into the editor's code block for the next collaborator.
+- Jot down insights in `docs/tutorials/notes.md` (create if needed) so others can build on your approach.
+
+You now have a personalized glitch aesthetic ready for further iteration or performance.

--- a/docs/tutorials/02-live-interaction.md
+++ b/docs/tutorials/02-live-interaction.md
@@ -1,0 +1,120 @@
+# Tutorial 02: Animate and Perform a Sketch
+
+Transform the static glitch preset into a live piece that responds to time and pointer movement.
+
+## 1. Prepare the canvas for animation
+
+1. In `setup()`, remove `noLoop();` or comment it out so p5 keeps calling `draw()`.
+2. At the top of the file, add a flag that lets you pause later:
+
+   ```js
+   let isFrozen = false;
+   ```
+
+3. Inside `draw()`, exit early when frozen:
+
+   ```js
+   if (isFrozen) {
+     image(img, 0, 0);
+     return;
+   }
+   ```
+
+Now the sketch continuously refreshes, ready for dynamic effects.
+
+## 2. Add frame-driven modulation
+
+1. Before iterating over `config.effectChain`, stash `frameCount` into a helper:
+
+   ```js
+   const t = frameCount * 0.02;
+   ```
+
+2. Replace the `rgbOffset` parameters with animated values:
+
+   ```js
+   { name:'rgbOffset', params:{
+       maxOffset: 10 + sin(t) * 8,
+       alpha: 120 + sin(t * 0.5) * 60
+   } },
+   ```
+
+3. Adjust `noise` strength over time:
+
+   ```js
+   { name:'noise', params:{ strength: 10 + abs(sin(t * 1.8)) * 25 } },
+   ```
+
+The image now breathes, wobbling in sync with the time variable.
+
+## 3. Respond to pointer movement
+
+1. Add a module-scope variable for mouse influence:
+
+   ```js
+   let pointerShift = 0;
+   ```
+
+2. Implement `mouseMoved()` (or `touchMoved()` for trackpads):
+
+   ```js
+   function mouseMoved() {
+     pointerShift = map(mouseX, 0, width, 0, 40);
+   }
+   ```
+
+3. Feed `pointerShift` into the slice effects:
+
+   ```js
+   { name:'hSliceShift', params:{ bands: 16, maxShift: 15 + pointerShift } },
+   { name:'vSliceTear', params:{ slices: 8, maxShift: 8 + pointerShift * 0.6 } },
+   ```
+
+Sweeping across the canvas now intensifies the tearing.
+
+## 4. Toggle performance modes from the keyboard
+
+1. Add a `keyPressed()` handler:
+
+   ```js
+   function keyPressed() {
+     if (key === ' ') {
+       isFrozen = !isFrozen;
+       if (!isFrozen) {
+         loop();
+       } else {
+         noLoop();
+       }
+     }
+     if (key === 's') {
+       saveCanvas('mesh-frame', 'png');
+     }
+   }
+   ```
+
+2. With this in place, tap the space bar to freeze and resume. Press `s` to save a PNG snapshot locally.
+
+## 5. Clean up the ghost buffer
+
+Because the ghosting effect relies on storing previous frames, add a reset when unfreezing:
+
+```js
+if (!isFrozen) {
+  ghostBuf.clear();
+  loop();
+}
+```
+
+Call this snippet right after toggling `isFrozen` to prevent stale trails when resuming.
+
+## 6. Rehearse the performance
+
+- Disable auto-run; you now control timing through the keyboard.
+- Practice a sequence: tweak the pointer to push the slice offsets, freeze, adjust parameters, unfreeze, repeat.
+- Consider assigning each major variation to a caption in the console so you can document the show later.
+
+## 7. Publish a highlight frame
+
+When you capture a compelling moment with the `s` shortcut, open the share panel and post the most striking still to Bluesky. Note the live performance context in the caption so viewers know it is part of a moving piece.
+
+You now have a sketch that can be performed in real time during workshops or streaming sessions.

--- a/docs/tutorials/03-dynamic-controls.md
+++ b/docs/tutorials/03-dynamic-controls.md
@@ -1,0 +1,110 @@
+# Tutorial 03: Build Live Controls
+
+Create a controllable version of the glitch sketch by wiring keyboard shortcuts and lightweight UI overlays. The goal is to nudge parameters in real time without digging back into the code each time.
+
+## 1. Define a control state object
+
+1. Near the top of the sketch add a `controls` object and expose it on `window` for debugging:
+
+   ```js
+   const controls = {
+     pixelateSize: 24,
+     rgbOffsetMax: 12,
+     noiseStrength: 18,
+     showHud: true,
+   };
+   window.controls = controls;
+   ```
+
+2. Replace hard-coded values with references to `controls`. Example:
+
+   ```js
+   { name:'pixelate', params:{ size: controls.pixelateSize } },
+   { name:'rgbOffset', params:{ maxOffset: controls.rgbOffsetMax, alpha: 140 } },
+   { name:'noise', params:{ strength: controls.noiseStrength } },
+   ```
+
+## 2. Add keyboard shortcuts for parameter nudges
+
+1. Implement `keyPressed()` and listen for sensible keys:
+
+   ```js
+   function keyPressed() {
+     if (key === '1') controls.pixelateSize = max(4, controls.pixelateSize - 4);
+     if (key === '2') controls.pixelateSize += 4;
+     if (key === '3') controls.rgbOffsetMax = max(0, controls.rgbOffsetMax - 2);
+     if (key === '4') controls.rgbOffsetMax += 2;
+     if (key === '5') controls.noiseStrength = max(0, controls.noiseStrength - 2);
+     if (key === '6') controls.noiseStrength += 2;
+     if (key === 'H' || key === 'h') controls.showHud = !controls.showHud;
+     redraw();
+   }
+   ```
+
+2. Remove `noLoop()` in `setup()` or call `redraw()` explicitly (as shown) so the canvas refreshes when parameters change.
+
+## 3. Render a heads-up display (HUD)
+
+1. After applying the effect chain in `draw()`, overlay the current settings:
+
+   ```js
+   if (controls.showHud) {
+     push();
+     fill(0, 160);
+     rect(12, 12, 220, 90, 12);
+     fill(255);
+     textSize(12);
+     textAlign(LEFT, TOP);
+     const lines = [
+       `Pixelate: ${controls.pixelateSize}`,
+       `RGB Offset: ${controls.rgbOffsetMax}`,
+       `Noise: ${controls.noiseStrength}`,
+       '1/2,3/4,5/6 adjust params',
+       'H toggles HUD',
+     ];
+     lines.forEach((line, idx) => text(line, 24, 24 + idx * 16));
+     pop();
+   }
+   ```
+
+2. Use `push()`/`pop()` to avoid leaking text styling into the rest of the sketch.
+
+## 4. Persist custom settings between runs
+
+1. Before exporting or sharing, capture the current configuration with `console.log('controls', JSON.stringify(controls));`.
+2. Copy the JSON output into a new constant:
+
+   ```js
+   const savedPreset = { pixelateSize: 12, rgbOffsetMax: 18, noiseStrength: 28 };
+   Object.assign(controls, savedPreset);
+   ```
+
+3. On load, the sketch uses your saved numbers. Keep the log in the console for future sessions.
+
+## 5. Optional: mouse drag for continuous control
+
+1. Track horizontal drag distance while the mouse button is held:
+
+   ```js
+   let dragStartX = null;
+
+   function mousePressed() {
+     dragStartX = mouseX;
+   }
+
+   function mouseDragged() {
+     if (dragStartX !== null) {
+       const delta = mouseX - dragStartX;
+       controls.rgbOffsetMax = constrain(12 + delta * 0.05, 0, 40);
+       redraw();
+     }
+   }
+
+   function mouseReleased() {
+     dragStartX = null;
+   }
+   ```
+
+2. This gives you an intuitive slider mapped to the canvas width.
+
+You now have a sketch that behaves like a mini instrument - quick tweaks happen through both keys and pointer gestures. Capture settings in console logs so collaborators can replay your performance.

--- a/docs/tutorials/04-archive-ready-export.md
+++ b/docs/tutorials/04-archive-ready-export.md
@@ -1,0 +1,133 @@
+# Tutorial 04: Curate Online Source Images
+
+This tutorial assumes you are using the hosted MESH editor in the browser. You will learn how to control Picsum seeds, curate a reusable image set, and load your own online assets without touching the project filesystem.
+
+## 1. Inspect the default image loader
+
+Open the editor and look near the top of the sketch for:
+
+```js
+img = loadImage('https://picsum.photos/600');
+```
+
+The Picsum service returns a random square photo every time the URL is requested. That is perfect for quick experiments, but it can make it hard to reproduce a remix later.
+
+## 2. Lock Picsum to a specific seed
+
+Update the `loadImage` call so the URL contains a seed. All edits happen in the browser editor.
+
+```js
+const picsumSeed = 'mesh-zine-01';
+const picsumSize = 600;
+img = loadImage(`https://picsum.photos/seed/${picsumSeed}/${picsumSize}/${picsumSize}`);
+```
+
+Refreshing or rerunning the sketch now pulls the same photo. Change `picsumSeed` whenever you want a new base image. Add `console.log('seed', picsumSeed);` so friends can recreate your setup.
+
+### Optional Picsum tweaks
+
+Append query parameters directly in the template string:
+
+```js
+`https://picsum.photos/seed/${picsumSeed}/${picsumSize}/${picsumSize}?grayscale&blur=2`
+```
+
+## 3. Cycle through a curated seed list
+
+Keep a short array of meaningful seeds and switch between them with a key press.
+
+```js
+const picsumSeeds = ['mesh-neon', 'mesh-dust', 'mesh-forest'];
+let seedIndex = 0;
+
+function preload() {
+  loadSeed(seedIndex);
+}
+
+function keyPressed() {
+  if (key === 'n') {
+    seedIndex = (seedIndex + 1) % picsumSeeds.length;
+    loadSeed(seedIndex);
+  }
+}
+
+function loadSeed(index) {
+  const seed = picsumSeeds[index];
+  loadImage(`https://picsum.photos/seed/${seed}/600/600`, (next) => {
+    img = next;
+    redraw();
+    console.log('Loaded seed', seed);
+  });
+}
+```
+
+Press `n` to move through the set. The console log doubles as a session journal.
+
+## 4. Use your own online images
+
+If you want to work from personal material, upload the files to an image host (for example, an S3 bucket, Supabase storage, Dropbox direct link, or an artist portfolio site) and copy the direct URL. Then load it from within the editor.
+
+```js
+const sources = [
+  'https://example-bucket.s3.amazonaws.com/mesh/collage-01.jpg',
+  'https://example-bucket.s3.amazonaws.com/mesh/collage-02.jpg',
+];
+let sourceIndex = 0;
+
+function preload() {
+  loadSource(sourceIndex);
+}
+
+function keyPressed() {
+  if (key === 'm') {
+    sourceIndex = (sourceIndex + 1) % sources.length;
+    loadSource(sourceIndex);
+  }
+}
+
+function loadSource(index) {
+  loadImage(sources[index], (next) => {
+    img = next;
+    redraw();
+    console.log('Loaded custom asset', sources[index]);
+  }, (err) => {
+    console.error('Failed to load asset', sources[index], err);
+  });
+}
+```
+
+Make sure the host serves the image over HTTPS and allows hotlinking. Some providers require you to create expiring signed URLs instead of public links.
+
+### Quick way to host a single file
+
+- Drag the image into a GitHub gist, Dropbox, or another service that returns a raw image URL.
+- Copy the URL and drop it into the `sources` array.
+- If the provider gives you a preview URL that ends with query parameters, look for a `raw` link or the `?raw=1` variant so `loadImage` receives the binary file.
+
+## 5. Reference Bluesky uploads
+
+Already sharing work on Bluesky? Each post attachment is hosted on a stable CDN. Right click the image in your post, copy the image address, and paste that URL into the `sources` array. This is a quick way to remix a previous frame inside MESH.
+
+## 6. Track attribution
+
+Keep metadata next to your code so licensing details travel with the sketch.
+
+```js
+const metadata = {
+  source: sources[sourceIndex],
+  author: '@your-handle',
+  license: 'CC-BY-SA',
+};
+
+console.log('Source metadata', metadata);
+```
+
+Mention credit and licensing in any Bluesky caption you publish through the share panel.
+
+## 7. Troubleshooting remote images
+
+- **CORS error in the console**: the host does not allow cross-origin requests. Re-upload the image somewhere that sets permissive headers or uses a signed URL feature.
+- **404 or 403**: double check that the link points directly to the file and, if needed, refresh the signed URL token.
+- **Slow loading**: use `loadImage(url, success, error);` with callbacks (as in the snippets above) so you can display placeholders or retry gracefully.
+
+With a reliable image source strategy, you can build collections of seeds or personal assets entirely from the browser and keep your remixes reproducible for everyone visiting the hosted MESH editor.


### PR DESCRIPTION
- reshape README.md so contributors land on clear setup steps, architecture cues, and quality checks without hunting through the repo

- launch a docs hub at docs/index.md that points to an IDE tour, remix playbook, and an expanded tutorial series

- drop in two new browser-friendly lessons: live HUD/keyboard controls and sourcing images via Picsum or hosted assets

- tighten cross-links, keep the markdown ASCII-clean, and make the whole doc stack GitHub Pages ready